### PR TITLE
Websockex version is updated with 0.4.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule App.Mixfile do
       {:hunter, git: "https://github.com/4DA/hunter.git", branch: "master"},
       # for local debugging:
       # {:hunter, path: "deps/hunter"},
-      {:websockex, "~> 0.4.2"},
+      {:websockex, "~> 0.4.3"},
       {:html_sanitize_ex, "~> 1.4.0"},
       {:cachex, "~> 3.2"}
     ]


### PR DESCRIPTION
Follows the issue https://github.com/Azolo/websockex/issues/96
Also suggest to adjust the environment as mentioned in the issue:
Elixir 1.11.3
Erlang/OTP 23.2